### PR TITLE
Add support for OMNeT++ 6.0

### DIFF
--- a/src/fico4omnet/nodes/flexray/FRNode.ned
+++ b/src/fico4omnet/nodes/flexray/FRNode.ned
@@ -48,8 +48,8 @@ module FRNode
         int gdActionPointOffset = default(1); //[MT]
         int gdMinislotActionPointOffset = default(1); //[MT]
         double bandwidth @unit(bps) = default(10000000bps); //[MBit/s]
-        double maxDriftChange @unit(s) = default(0);
-        double maxDrift @unit(s) = default(0);
+        double maxDriftChange @unit(s) = default(0s);
+        double maxDrift @unit(s) = default(0s);
 
 //        @node;
 

--- a/src/fico4omnet/scheduler/can/CanClock.ned
+++ b/src/fico4omnet/scheduler/can/CanClock.ned
@@ -32,9 +32,9 @@ simple CanClock
     	@statistic[clockDrift](title="clockDrift"; source=clockDrift; unit=s; record=stats,histogram?,vector; interpolationmode=linear);
     	
     	//Maximum drift per second
-    	double maxDrift @unit(s) = default(0);
+    	double maxDrift @unit(s) = default(0s);
     	//Maximum drift change per second
-    	double maxDriftChange @unit(s) = default(0);
+    	double maxDriftChange @unit(s) = default(0s);
     	//True if the node should have a random drift at the start of the simulation, false otherwise.
     	bool randomStartDrift = default(true);
 }

--- a/src/fico4omnet/scheduler/flexray/FRScheduler.ned
+++ b/src/fico4omnet/scheduler/flexray/FRScheduler.ned
@@ -38,12 +38,12 @@ simple FRScheduler
         int gdActionPointOffset = default(1); //[MT]
         int gdMinislotActionPointOffset = default(1); //[MT]
         double busSpeed @unit(bps) = default(10000000bps); //[MBit/s]     
-        double maxDriftChange @unit(s) = default(0);
-        double maxDrift @unit(s) = default(0);       
+        double maxDriftChange @unit(s) = default(0s);
+        double maxDrift @unit(s) = default(0s);       
         string staticSlotsChA = default(""); 
         string staticSlotsChB = default("");
         string dynamicSlotsChA = default("");
         string dynamicSlotsChB = default("");
         int syncFrame = default(0);       
-        double currentTick @unit(s) = default(0);
+        double currentTick @unit(s) = default(0s);
 }

--- a/src/makefrag
+++ b/src/makefrag
@@ -63,3 +63,5 @@ endif
 
 COPTS += $(SYSINCLUDES) -isystem $(OMNETPP_INCL_DIR)
 
+# use legacy message compiler (available since OMNeT++ 5.3)
+MSGC += --msg4


### PR DESCRIPTION
- appended missing unit to parameters to fix error `Can not convert unit none to 's' (second)`
- fixed message compiler errors by using legacy message compiler (although this is not the optimal solution, I didn't find out what exactly needs to be changed for the new message format)
```
fico4omnet/scheduler/flexray/SchedulerMessageEvents.msg:7: Error: Type declarations are not needed with imports, try invoking the message compiler in legacy (4.x) mode using the --msg4 option
fico4omnet/scheduler/flexray/SchedulerMessageEvents.msg:16: Error: 'SchedulerActionTimeEvent': unknown base class 'SchedulerEvent'
fico4omnet/scheduler/flexray/SchedulerMessageEvents.msg:16: Error: SchedulerActionTimeEvent: base class is not a message (must be derived from omnetpp::cMessage)
fico4omnet/scheduler/flexray/SchedulerMessageEvents.msg:32: Error: 'SchedulerTimerEvent': unknown base class 'SchedulerEvent'
fico4omnet/scheduler/flexray/SchedulerMessageEvents.msg:32: Error: SchedulerTimerEvent: base class is not a message (must be derived from omnetpp::cMessage)
```

All changes are backwards compatible with OMNeT++ 5.3+.